### PR TITLE
Set the pyenv root using a custom variable- $TRAVISPYENV_ROOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     # Use PYENV_VERSION with PyPy
     - env: PYENV_VERSION=pypy2.7-5.9.0 PYENV_VERSION_STRING='PyPy 5.9.0'
     # Use PYENV_VERSION with PyPy and custom options
-    - env: PYENV_VERSION=pypy3.5-5.9.0 PYENV_VERSION_STRING='PyPy 5.9.0-beta0' TRAVISPYENV_ROOT=$HOME/.pyenv-pypy PYENV_RELEASE=v1.1.5 PYENV_CACHE_PATH=$HOME/.pyenv-pypy-cache
+    - env: PYENV_VERSION=pypy3.5-5.8.0 PYENV_VERSION_STRING='PyPy 5.8.0-beta0' TRAVISPYENV_ROOT=$HOME/.pyenv-pypy PYENV_RELEASE=v1.1.5 PYENV_CACHE_PATH=$HOME/.pyenv-pypy-cache
     # Legacy setup-pypy.sh
     - env: PYPY_VERSION=5.7.1 SETUP_SCRIPT=setup-pypy.sh
     # macOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: python
 dist: trusty
+
+branches:
+  only:
+    - develop
+    - master
+    - /^\d+\.\d+(\.\d+)?$/
+
 matrix:
   include:
     # Normal method of specifying Python version

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     # Use PYENV_VERSION with PyPy
     - env: PYENV_VERSION=pypy2.7-5.9.0 PYENV_VERSION_STRING='PyPy 5.9.0'
     # Use PYENV_VERSION with PyPy and custom options
-    - env: PYENV_VERSION=pypy3.5-5.9.0 PYENV_VERSION_STRING='PyPy 5.9.0-beta0' PYENV_ROOT=$HOME/.pyenv-pypy PYENV_RELEASE=v1.1.5 PYENV_CACHE_PATH=$HOME/.pyenv-pypy-cache
+    - env: PYENV_VERSION=pypy3.5-5.9.0 PYENV_VERSION_STRING='PyPy 5.9.0-beta0' TRAVISPYENV_ROOT=$HOME/.pyenv-pypy PYENV_RELEASE=v1.1.5 PYENV_CACHE_PATH=$HOME/.pyenv-pypy-cache
     # Legacy setup-pypy.sh
     - env: PYPY_VERSION=5.7.1 SETUP_SCRIPT=setup-pypy.sh
     # macOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ matrix:
     # Normal method of specifying Python version
     - python: '2.7'
     # Use PYENV_VERSION with CPython, specific major.minor.change version
-    - env: PYENV_VERSION=3.6.1 PYENV_VERSION_STRING='Python 3.6.1'
+    - env: PYENV_VERSION=3.6.3 PYENV_VERSION_STRING='Python 3.6.3'
     # Use PYENV_VERSION with PyPy
-    - env: PYENV_VERSION=pypy2.7-5.8.0 PYENV_VERSION_STRING='PyPy 5.8.0'
+    - env: PYENV_VERSION=pypy2.7-5.9.0 PYENV_VERSION_STRING='PyPy 5.9.0'
     # Use PYENV_VERSION with PyPy and custom options
-    - env: PYENV_VERSION=pypy3.5-portable-5.8.0 PYENV_VERSION_STRING='PyPy 5.8.0-beta0' PYENV_ROOT=$HOME/.pyenv-pypy PYENV_RELEASE=v1.1.2 PYENV_CACHE_PATH=$HOME/.pyenv-pypy-cache
+    - env: PYENV_VERSION=pypy3.5-portable-5.9.0 PYENV_VERSION_STRING='PyPy 5.9.0-beta0' PYENV_ROOT=$HOME/.pyenv-pypy PYENV_RELEASE=v1.1.5 PYENV_CACHE_PATH=$HOME/.pyenv-pypy-cache
     # Legacy setup-pypy.sh
     - env: PYPY_VERSION=5.7.1 SETUP_SCRIPT=setup-pypy.sh
     # macOS
@@ -21,13 +21,13 @@ matrix:
     # check can attest, we are still fine.
     - os: osx
       language: ruby
-      env: PYENV_VERSION=3.6.1 PYENV_VERSION_STRING='Python 3.6.1'
+      env: PYENV_VERSION=3.6.3 PYENV_VERSION_STRING='Python 3.6.3'
     # macOS Framework Build
     # Useful for PyInstaller
     # Example issue: https://github.com/pyenv/pyenv/issues/443
     - os: osx
       language: ruby
-      env: PYENV_VERSION=3.6.1 PYENV_VERSION_STRING='Python 3.6.1' PYTHON_CONFIGURE_OPTS="--enable-framework"
+      env: PYENV_VERSION=3.6.3 PYENV_VERSION_STRING='Python 3.6.3' PYTHON_CONFIGURE_OPTS="--enable-framework"
 
     - env: SETUP_SCRIPT=/dev/null SHELLCHECK=1
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     # Use PYENV_VERSION with PyPy
     - env: PYENV_VERSION=pypy2.7-5.9.0 PYENV_VERSION_STRING='PyPy 5.9.0'
     # Use PYENV_VERSION with PyPy and custom options
-    - env: PYENV_VERSION=pypy3.5-portable-5.9.0 PYENV_VERSION_STRING='PyPy 5.9.0-beta0' PYENV_ROOT=$HOME/.pyenv-pypy PYENV_RELEASE=v1.1.5 PYENV_CACHE_PATH=$HOME/.pyenv-pypy-cache
+    - env: PYENV_VERSION=pypy3.5-5.9.0 PYENV_VERSION_STRING='PyPy 5.9.0-beta0' PYENV_ROOT=$HOME/.pyenv-pypy PYENV_RELEASE=v1.1.5 PYENV_CACHE_PATH=$HOME/.pyenv-pypy-cache
     # Legacy setup-pypy.sh
     - env: PYPY_VERSION=5.7.1 SETUP_SCRIPT=setup-pypy.sh
     # macOS

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Set up [pyenv](https://github.com/yyuu/pyenv) to use in [Travis CI](https://travis-ci.org) builds.
 
+> NOTE: Because Travis' build environments now seem to set `$PYENV_ROOT` and we need our own location for the pyenv root, the value is now set using `$TRAVISPYENV_ROOT` rather.
+
 Setting up pyenv properly in a Travis CI build environment can be quite tricky. This repo contains a script ([`setup-pyenv.sh`](setup-pyenv.sh)) that makes this process much simpler.
 
 Use cases for this include:
@@ -24,7 +26,7 @@ There are a few install options that can be set via environment variables:
     The pyenv to install [required]
 * `PYENV_VERSION_STRING`
     String to `grep -F` against the output of `python --version` to validate that the correct Python was installed (recommended) [default: none]
-* `PYENV_ROOT`
+* `TRAVISPYENV_ROOT`
     Directory in which to install pyenv [default: `~/.travis-pyenv`]
 * `PYENV_RELEASE`
     Release tag of pyenv to download [default: clone from master]
@@ -62,5 +64,5 @@ script:
 * Some recent PyPy versions and all recent ["Portable PyPy"](https://github.com/squeaky-pl/portable-pypy) versions **require Travis' [Trusty CI build environment](https://docs.travis-ci.com/user/trusty-ci-environment/)**. See [pyenv/pyenv#925](https://github.com/pyenv/pyenv/issues/925).
 * Installing pyenv by downloading a release tag rather than cloning the git repo can make your builds a bit faster in some cases. Set the `PYENV_RELEASE` environment variable to achieve that.
 * If you want to use `$PYENV_CACHE_PATH`, you must also set up Travis to cache this directory in your Travis configuration. Using the cache is optional, but it can greatly speed up subsequent builds.
-* The `$PYENV_ROOT` defaults to `~/.travis-pyenv`, rather than the usual `~/.pyenv`. This is because some of Travis' Trusty build environments already have a pyenv install in this location.
-* pyenv fails to install properly if the `$PYENV_ROOT` is already present, even if the directory is empty. So if you set Travis to cache any directories within the pyenv root, then you will probably break pyenv. For this reason, Python builds are cached outside the pyenv root and then linked after pyenv is installed.
+* The `$PYENV_ROOT` defaults to `~/.travis-pyenv`, rather than the usual `~/.pyenv`. This is because some of Travis' Trusty build environments already have a pyenv install in this location. Also, this value is adjusted with the `$TRAVISPYENV_ROOT` variable rather than `$PYENV_ROOT` as Travis may set `$PYENV_ROOT` itself.
+* pyenv fails to install properly if the `$TRAVISPYENV_ROOT` is already present, even if the directory is empty. So if you set Travis to cache any directories within the pyenv root, then you will probably break pyenv. For this reason, Python builds are cached outside the pyenv root and then linked after pyenv is installed.

--- a/setup-pyenv.sh
+++ b/setup-pyenv.sh
@@ -7,7 +7,7 @@
 # - PYENV_VERSION_STRING
 #     String to `grep -F` against the output of `python --version` to validate
 #     that the correct Python was installed (recommended) [default: none]
-# - PYENV_ROOT
+# - TRAVISPYENV_ROOT
 #     Directory in which to install pyenv [default: ~/.travis-pyenv]
 # - PYENV_RELEASE
 #     Release tag of pyenv to download [default: clone from master]
@@ -15,7 +15,7 @@
 #     Directory where full Python builds are cached (i.e., for Travis)
 
 # PYENV_ROOT is exported because pyenv uses it
-export PYENV_ROOT="${PYENV_ROOT:-$HOME/.travis-pyenv}"
+export PYENV_ROOT="${TRAVISPYENV_ROOT:-$HOME/.travis-pyenv}"
 PYENV_CACHE_PATH="${PYENV_CACHE_PATH:-$HOME/.pyenv_cache}"
 version_cache_path="$PYENV_CACHE_PATH/$PYENV_VERSION"
 version_pyenv_path="$PYENV_ROOT/versions/$PYENV_VERSION"

--- a/setup-pypy.sh
+++ b/setup-pypy.sh
@@ -5,7 +5,7 @@
 # Environment variables that can be set:
 # - PYPY_VERSION
 #     Version of PyPy2 to install [required]
-# - PYENV_ROOT
+# - TRAVISPYENV_ROOT
 #     Directory in which to install pyenv [default: ~/.travis-pyenv]
 # - PYENV_RELEASE
 #     Release tag of pyenv to download [default: clone from master]


### PR DESCRIPTION
I don't want to start the variable with `$TRAVIS_` because then it sounds like Travis sets it not us.

Alternative could be `$PYENV_TRAVIS_ROOT` but that might be confusing if we're `travis-pyenv`?